### PR TITLE
Replace KMP_INTERNAL_FREE by __kmp_free for freeing ompd_env_block

### DIFF
--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -7535,7 +7535,7 @@ void __kmp_cleanup(void) {
 #endif
 #if OMPD_SUPPORT
   if (ompd_state) {
-    KMP_INTERNAL_FREE(ompd_env_block);
+    __kmp_free(ompd_env_block);
     ompd_env_block = NULL;
     ompd_env_block_size = 0;
   }


### PR DESCRIPTION
Since ompd_env_block was allocated using __kmp_allocate(), it needs to be freed using __kmp_free(). Trying to free ompd_env_block using KMP_INTERNAL_FREE() was resulting in a crash with 'munmap_chunk(): invalid pointer'. This patch fixes this issue. 

I have not checked if there are other cases where __kmp_allocate/KMP_INTERNAL_MALLOC/__kmp_free/KMP_INTERNAL_FREE have been mixed. 

Also, freeing the ompd_env_block is guarded by "if (ompd_state)", while the corresponding __kmp_allocate() is not (since ompd_state gets set later). This will be fixed in a later patch. 