### PR TITLE
ompd_bp_parallel_begin() needs to be called for all parallel constructs and not only for serialized regi

### DIFF
--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -1497,17 +1497,6 @@ int __kmp_fork_call(ident_t *loc, int gtid,
     }
 #endif
 
-#if OMPD_SUPPORT
-    if ( ompd_state & OMPD_ENABLE_BP ) {
-       // Invoke ompd_bp_parallel_begin() only for the parallel construct, and
-       // not for the teams construct.
-       if ((master_th->th.th_teams_microtask != microtask) &&
-           microtask != (microtask_t)__kmp_teams_master) {
-           ompd_bp_parallel_begin ();
-       }
-    }
-#endif
-
     master_th->th.th_ident = loc;
 
     if (master_th->th.th_teams_microtask && ap &&
@@ -2086,6 +2075,11 @@ int __kmp_fork_call(ident_t *loc, int gtid,
 
     // Update the floating point rounding in the team if required.
     propagateFPControl(team);
+#if OMPD_SUPPORT
+    if ( ompd_state & OMPD_ENABLE_BP )
+      ompd_bp_parallel_begin ();
+#endif
+
 
     if (__kmp_tasking_mode != tskm_immediate_exec) {
       // Set master's task team to team's task team. Unless this is hot team, it

--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -1497,6 +1497,17 @@ int __kmp_fork_call(ident_t *loc, int gtid,
     }
 #endif
 
+#if OMPD_SUPPORT
+    if ( ompd_state & OMPD_ENABLE_BP ) {
+       // Invoke ompd_bp_parallel_begin() only for the parallel construct, and
+       // not for the teams construct.
+       if ((master_th->th.th_teams_microtask != microtask) &&
+           microtask != (microtask_t)__kmp_teams_master) {
+           ompd_bp_parallel_begin ();
+       }
+    }
+#endif
+
     master_th->th.th_ident = loc;
 
     if (master_th->th.th_teams_microtask && ap &&
@@ -1564,10 +1575,6 @@ int __kmp_fork_call(ident_t *loc, int gtid,
         {
           KMP_TIME_PARTITIONED_BLOCK(OMP_parallel);
           KMP_SET_THREAD_STATE_BLOCK(IMPLICIT_TASK);
-#if OMPD_SUPPORT
-          if ( ompd_state & OMPD_ENABLE_BP )
-            ompd_bp_parallel_begin ();
-#endif
           __kmp_invoke_microtask(microtask, gtid, 0, argc, parent_team->t.t_argv
 #if OMPT_SUPPORT
                                  ,

--- a/openmp/runtime/src/ompt-specific.cpp
+++ b/openmp/runtime/src/ompt-specific.cpp
@@ -285,19 +285,31 @@ void __ompt_lw_taskteam_link(ompt_lw_taskteam_t *lwt, kmp_info_t *thr,
     link_lwt->ompt_team_info = *OMPT_CUR_TEAM_INFO(thr);
     *OMPT_CUR_TEAM_INFO(thr) = tmp_team;
 
-    ompt_task_info_t tmp_task = lwt->ompt_task_info;
-    link_lwt->ompt_task_info = *OMPT_CUR_TASK_INFO(thr);
-    *OMPT_CUR_TASK_INFO(thr) = tmp_task;
-
     // link the taskteam into the list of taskteams:
     ompt_lw_taskteam_t *my_parent =
         thr->th.th_team->t.ompt_serialized_team_info;
     link_lwt->parent = my_parent;
     thr->th.th_team->t.ompt_serialized_team_info = link_lwt;
+
+#ifdef OMPD_SUPPORT
+    if (ompd_state & OMPD_ENABLE_BP) {
+      ompd_bp_parallel_begin ();
+    }
+#endif
+
+    ompt_task_info_t tmp_task = lwt->ompt_task_info;
+    link_lwt->ompt_task_info = *OMPT_CUR_TASK_INFO(thr);
+    *OMPT_CUR_TASK_INFO(thr) = tmp_task;
+
   } else {
     // this is the first serialized team, so we just store the values in the
     // team and drop the taskteam-object
     *OMPT_CUR_TEAM_INFO(thr) = lwt->ompt_team_info;
+#ifdef OMPD_SUPPORT
+    if (ompd_state & OMPD_ENABLE_BP) {
+      ompd_bp_parallel_begin ();
+    }
+#endif
     *OMPT_CUR_TASK_INFO(thr) = lwt->ompt_task_info;
   }
 }


### PR DESCRIPTION
Currently, the ompd_bp_parallel_start() routine gets called only in the case of serialized parallel regions. With this PR, I have made modifications so that this gets called at the beginning of the execution of every parallel construct. I had a couple of doubts which I raised in the group also.

•	I am assuming that ompd_bp_parallel_start() should get invoked only for the parallel constructs, and not for teams constructs (unlike the OMPT parallel begin events).
•	The spec mentions: At the point that the implementation reaches ompd_bp_parallel_begin, the binding for ompd_get_curr_parallel_handle is the parallel region that is beginning and the binding for ompd_get_curr_task_handle is the task that encountered the parallel construct. 
          This is not the case with the current sources or even with this PR. Currently, when the implementation reaches ompd_bp_parallel_begin(), the binding for the ompd_get_curr_parallel_handle() is the region enclosing the parallel region that is beginning. I feel that what the spec mentions wrt the parallel-begin event in the case of OMPT is more appropriate – where the following is mentioned there. 

Between a parallel-begin event and an implicit-task-begin event, a call to ompt_get_parallel_info(0,...) may return information about the outer parallel team,  the new parallel team or an inconsistent state.
