### PR TITLE
Ompd tests

### DIFF
--- a/openmp/libompd/src/CMakeLists.txt
+++ b/openmp/libompd/src/CMakeLists.txt
@@ -5,6 +5,27 @@ add_dependencies(ompd omp) # ensure generated import library is created first
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+set(LIBOMPD_LD_STD_FLAGS FALSE CACHE BOOL
+  "Use -stdlibc++ instead of -libc++ library for C++ ")
+
+if(${LIBOMPD_LD_STD_FLAGS})
+#  Find and replace/add libstdc++ to compile flags     
+   STRING( FIND "${CMAKE_CXX_FLAGS}" "-stdlib=libc++" OUT )
+   if("${OUT}" STREQUAL "-1" )   
+      set (CMAKE_CXX_FLAGS "-stdlib=libstdc++ ${CMAKE_CXX_FLAGS}")
+   else()
+      STRING( REPLACE "-stdlib=libc++" "-stdlib=libstdc++" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} )
+   endif()         
+
+#  Find and replace/add libstdc++ to loader flags
+   STRING( FIND "${CMAKE_SHARED_LINKER_FLAGS}" "-stdlib=libc++" OUT )
+   if("${OUT}" STREQUAL "-1" )   
+      set (CMAKE_SHARED_LINKER_FLAGS "-stdlib=libstdc++ ${CMAKE_SHARED_LINKER_FLAGS}")         
+   else()
+      STRING( REPLACE "-stdlib=libc++" "-stdlib=libstdc++" CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} )
+   endif()
+endif()
+
 include_directories (
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${LIBOMP_INCLUDE_DIR}
@@ -14,3 +35,6 @@ INSTALL( TARGETS ompd
         LIBRARY DESTINATION lib 
         ARCHIVE DESTINATION lib/static 
         RUNTIME DESTINATION bin )
+
+INSTALL(FILES ompd.h DESTINATION include)
+

--- a/openmp/libompd/src/CMakeLists.txt
+++ b/openmp/libompd/src/CMakeLists.txt
@@ -35,6 +35,3 @@ INSTALL( TARGETS ompd
         LIBRARY DESTINATION lib 
         ARCHIVE DESTINATION lib/static 
         RUNTIME DESTINATION bin )
-
-INSTALL(FILES ompd.h DESTINATION include)
-

--- a/openmp/libomptarget/deviceRTLs/common/ompd-specific.h
+++ b/openmp/libomptarget/deviceRTLs/common/ompd-specific.h
@@ -4,7 +4,6 @@
 #ifdef OMPD_SUPPORT
 
 #include "state-queue.h"
-#include "option.h"
 #include <stdint.h>
 
 

--- a/openmp/libomptarget/deviceRTLs/common/src/ompd-specific.cu
+++ b/openmp/libomptarget/deviceRTLs/common/src/ompd-specific.cu
@@ -1,6 +1,6 @@
 #ifdef OMPD_SUPPORT
-#include "ompd-specific.h"
-#include "omptarget.h"
+#include "../ompd-specific.h"   
+#include "../omptarget.h"
 /**
    * Declaration of symbols to hold struct size and member offset information
     */
@@ -19,13 +19,6 @@ OMPD_FOREACH_ACCESS(ompd_target_declare_access)
     OMPD_FOREACH_SIZEOF(ompd_target_declare_sizeof)
 #undef ompd_target_declare_sizeof
 
-__device__ __shared__
-  uint64_t ompd_access__omptarget_nvptx_TaskDescr__items__threadsInTeam_;
-
-__device__ __shared__
-  uint64_t ompd_sizeof__omptarget_nvptx_TaskDescr__items__threadsInTeam_;
-
-
 __device__ void ompd_init ( void )
 {
   if (ompd_target_initialized)
@@ -35,15 +28,9 @@ __device__ void ompd_init ( void )
   OMPD_FOREACH_ACCESS(ompd_target_init_access)
 #undef ompd_target_init_access
 
-  ompd_access__omptarget_nvptx_TaskDescr__items__threadsInTeam_ =
-          (uint64_t)&(((omptarget_nvptx_TaskDescr*)0)->items.threadsInTeam);
-
 #define ompd_target_init_sizeof_member(t,m) ompd_sizeof__##t##__##m##_ = sizeof(((t*)0)->m);
   OMPD_FOREACH_ACCESS(ompd_target_init_sizeof_member)
 #undef ompd_target_init_sizeof_member
-
-  ompd_sizeof__omptarget_nvptx_TaskDescr__items__threadsInTeam_ =
-    (uint64_t)sizeof(((omptarget_nvptx_TaskDescr*)0)->items.threadsInTeam);
 
 #define ompd_target_init_sizeof(t) ompd_sizeof__##t##_ = sizeof(t);
   OMPD_FOREACH_SIZEOF(ompd_target_init_sizeof)


### PR DESCRIPTION
  1. openmp/libompd/src/CMakeLists.txt
       Add an option to compile libompd.so with libstdc++ instead of libc++.
       See LIBOMPD_LD_STD_FLAGS:BOOL=FALSE
       Motivation: Debugger may not have clang installed on the machine that is debugging.
       LIBOMPD_LD_STD set to TRUE provides a way to give the debugger application at runtime a libompd.so without having to install clang distribution on that machine.
       Defaults to False which will use the CLANG libraries.