### PR TITLE
Incorrect entry point obtained by ompd_get_task_function() for the implicit task associated with a serialized parallel region

### DIFF
--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -1733,6 +1733,10 @@ int __kmp_fork_call(ident_t *loc, int gtid,
 
       __kmpc_serialized_parallel(loc, gtid);
 
+#if OMPD_SUPPORT
+      master_th->th.th_serial_team->t.t_pkfn = microtask;
+#endif
+
       if (call_context == fork_context_intel) {
         /* TODO this sucks, use the compiler itself to pass args! :) */
         master_th->th.th_serial_team->t.t_ident = loc;

--- a/openmp/runtime/src/kmp_runtime.cpp
+++ b/openmp/runtime/src/kmp_runtime.cpp
@@ -1521,6 +1521,10 @@ int __kmp_fork_call(ident_t *loc, int gtid,
         __kmpc_serialized_parallel(loc, gtid);
         KMP_DEBUG_ASSERT(parent_team->t.t_serialized > 1);
 
+#if OMPD_SUPPORT
+        parent_team->t.t_pkfn = microtask;
+#endif
+
 #if OMPT_SUPPORT
         void *dummy;
         void **exit_frame_p;


### PR DESCRIPTION
"t_pkfn" of the implicit task  associated with a serialized parallel region gets initialized to  -1, (due to the code snippet below in kmp_runtime.cpp), and remains unchanged -- causing the entry point address returned by ompd_get_task_function() for the implicit task to be set incorrectly to -1. 

3193 #if USE_DEBUGGER
3194   // Non-NULL value should be assigned to make the debugger display the root
3195   // team.
3196   TCW_SYNC_PTR(root_team->t.t_pkfn, (microtask_t)(~0));
3197 #endif 

Proposing to correct this by setting "t_pkfn" of the implicit task associated with the serialized parallel region to  'microtask' in __kmp_fork_call. 