### PR TITLE
Fix for: ompd_bp_task_end() gets invoked an incorrect number of times

### DIFF
--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -1564,6 +1564,10 @@ static void __kmp_invoke_task(kmp_int32 gtid, kmp_task_t *task,
 
   }
 
+#if OMPD_SUPPORT
+  if ( ompd_state & OMPD_ENABLE_BP )
+    ompd_bp_task_end ();
+#endif
 
   // Proxy tasks are not handled by the runtime
   if (taskdata->td_flags.proxy != TASK_PROXY) {

--- a/openmp/runtime/src/kmp_wait_release.h
+++ b/openmp/runtime/src/kmp_wait_release.h
@@ -748,18 +748,9 @@ public:
   int execute_tasks(kmp_info_t *this_thr, kmp_int32 gtid, int final_spin,
                     int *thread_finished USE_ITT_BUILD_ARG(void *itt_sync_obj),
                     kmp_int32 is_constrained) {
-#if OMPD_SUPPORT
-      int ret = __kmp_execute_tasks_32(
-        this_thr, gtid, this, final_spin,
-        thread_finished USE_ITT_BUILD_ARG(itt_sync_obj), is_constrained);
-      if ( ompd_state & OMPD_ENABLE_BP )
-          ompd_bp_task_end ();
-      return ret;
-#else
     return __kmp_execute_tasks_32(
         this_thr, gtid, this, final_spin,
         thread_finished USE_ITT_BUILD_ARG(itt_sync_obj), is_constrained);
-#endif
   }
   void wait(kmp_info_t *this_thr,
             int final_spin USE_ITT_BUILD_ARG(void *itt_sync_obj)) {
@@ -786,18 +777,9 @@ public:
   int execute_tasks(kmp_info_t *this_thr, kmp_int32 gtid, int final_spin,
                     int *thread_finished USE_ITT_BUILD_ARG(void *itt_sync_obj),
                     kmp_int32 is_constrained) {
-#if OMPD_SUPPORT
-      int ret = __kmp_execute_tasks_64(
-        this_thr, gtid, this, final_spin, 
-        thread_finished USE_ITT_BUILD_ARG(itt_sync_obj), is_constrained);
-      if ( ompd_state & OMPD_ENABLE_BP )
-          ompd_bp_task_end ();
-      return ret;
-#else
     return __kmp_execute_tasks_64(
         this_thr, gtid, this, final_spin,
         thread_finished USE_ITT_BUILD_ARG(itt_sync_obj), is_constrained);
-#endif
   }
   void wait(kmp_info_t *this_thr,
             int final_spin USE_ITT_BUILD_ARG(void *itt_sync_obj)) {


### PR DESCRIPTION
The runtime entry point ompd_bp_task_end() was getting invoked an incorrect number of times -- since it was getting invoked from the wrong location. This PR is to correct that. One issue that lingers even after this fix is that: ompd_bp_task_end() gets triggered a few extra times if the task is untied.  (This hold true for the ompd_bp_task_begin() also currently). I plan to fix that in a separate PR. 