### PR TITLE
PR to introduce 2 gdb plugin commands and some fixes

### DIFF
--- a/openmp/libompd/gdb-plugin/CMakeLists.txt
+++ b/openmp/libompd/gdb-plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python-module/loadompd.py
                    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v bdist_wheel -b ${CMAKE_CURRENT_BINARY_DIR}/build -d ${CMAKE_CURRENT_BINARY_DIR}
                    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py clean --all
                    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/ompd.egg-info
-                   COMMAND ${PYTHON_EXECUTABLE} -m pip install -U -t ${CMAKE_CURRENT_BINARY_DIR}/python-module --no-index --find-links=${CMAKE_CURRENT_BINARY_DIR} ompd
+                   COMMAND ${PYTHON_EXECUTABLE} -m pip install --system -U -t ${CMAKE_CURRENT_BINARY_DIR}/python-module --no-index --find-links=${CMAKE_CURRENT_BINARY_DIR} ompd
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(ompd_gdb_plugin ALL

--- a/openmp/libompd/gdb-plugin/ompd/ompd_callbacks.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_callbacks.py
@@ -27,17 +27,13 @@ def _sym_addr(*args):
 """ Read string from the target and copy it into the provided buffer.
 """
 def _read_string(*args):
-	# args is a tuple consisting of address and number of bytes to be read
+	# args is a tuple with just the source address
 	addr = args[0]
-	nbytes = args[1]
-	ret_buf = str()
 	try:
-		buf = gdb.parse_and_eval('(unsigned char*)%li' % addr)
-		for i in range(nbytes):
-			ret_buf.append(b'%c' % buf[i])
+		buf = gdb.parse_and_eval('(unsigned char*)%li' % addr).string()
 	except:
 		traceback.print_exc()
-	return ret_buf
+	return buf
 
 """ Read memory from the target and copy it into the provided buffer.
 """

--- a/openmp/libompd/gdb-plugin/ompd/ompd_handles.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_handles.py
@@ -141,8 +141,7 @@ class ompd_thread(object):
 	def get_current_parallel_handle(self):
 		"""Obtains the parallel handle for the parallel region associated with
 		the given thread handle."""
-		if not self.parallel_handle:
-			self.parallel_handle = ompdModule.call_ompd_get_curr_parallel_handle(self.thread_handle)
+		self.parallel_handle = ompdModule.call_ompd_get_curr_parallel_handle(self.thread_handle)
 		return self.parallel_handle
 	
 	def get_current_parallel(self):

--- a/openmp/libompd/gdb-plugin/ompd/ompd_handles.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_handles.py
@@ -141,6 +141,7 @@ class ompd_thread(object):
 	def get_current_parallel_handle(self):
 		"""Obtains the parallel handle for the parallel region associated with
 		the given thread handle."""
+		#TODO: invalidate thread objects based on `gdb.event.cont`. This should invalidate all internal state.
 		self.parallel_handle = ompdModule.call_ompd_get_curr_parallel_handle(self.thread_handle)
 		return self.parallel_handle
 	

--- a/openmp/libompd/gdb-plugin/ompdModule.c
+++ b/openmp/libompd/gdb-plugin/ompdModule.c
@@ -545,16 +545,12 @@ ompd_rc_t _read_string (
 {
 	uint64_t readMem = (uint64_t) addr->address;
 	PyObject* pFunc = PyObject_GetAttrString(pModule, "_read_string");
-	PyObject* pArgs = PyTuple_New(2);
+	PyObject* pArgs = PyTuple_New(1);
 	PyTuple_SetItem(pArgs, 0, Py_BuildValue("l", readMem));
-	PyTuple_SetItem(pArgs, 1, Py_BuildValue("i", nbytes));
 	PyObject* retString = PyObject_CallObject(pFunc, pArgs);
 	Py_XDECREF(pArgs);
-	if(!PyString_Check(retString)) {
-		return ompd_rc_error;
-	}
 	int retSize = (int) PyString_Size(retString);
-	if(retSize != nbytes) {
+	if(retSize >= nbytes) {
 		return ompd_rc_error;
 	}
 	char* strbuffer = (char*) buffer;
@@ -942,7 +938,9 @@ static PyObject* call_ompd_get_icv_from_scope(PyObject* self, PyObject* args) {
 	ompd_rc_t retVal = ompd_get_icv_from_scope(addrSpaceHandle, scope, icvId, &icvValue);
 	
 	if(retVal != ompd_rc_ok) {
-		_printf("An error occurred when calling ompd_get_icv_from_scope: Error code: %d", retVal);
+                if (retVal != ompd_rc_incompatible) {
+		    _printf("An error occurred when calling ompd_get_icv_from_scope: Error code: %d", retVal);
+                }
 		return Py_None;
 	}
 	return PyLong_FromLong(icvValue);

--- a/openmp/libompd/gdb-plugin/ompdModule.c
+++ b/openmp/libompd/gdb-plugin/ompdModule.c
@@ -550,13 +550,14 @@ ompd_rc_t _read_string (
 	PyObject* retString = PyObject_CallObject(pFunc, pArgs);
 	Py_XDECREF(pArgs);
 	int retSize = (int) PyString_Size(retString);
+	ompd_rc_t retVal = ompd_rc_ok;
 	if(retSize >= nbytes) {
-		return ompd_rc_error;
+		retVal = ompd_rc_incomplete;
 	}
 	char* strbuffer = (char*) buffer;
  	strncpy(strbuffer, PyString_AsString(retString), nbytes);
 	strbuffer[nbytes-1]='\0';
-	return ompd_rc_ok;
+	return retVal;
 }
 
 /**

--- a/openmp/runtime/src/include/omp-tools.h.var
+++ b/openmp/runtime/src/include/omp-tools.h.var
@@ -439,6 +439,8 @@ typedef enum ompd_rc_t {
   ompd_rc_device_read_error = 8,
   ompd_rc_device_write_error = 9,
   ompd_rc_nomem = 10,
+  ompd_rc_incomplete = 11,
+  ompd_rc_callback_error = 12
 } ompd_rc_t;
 
 typedef void (*ompt_interface_fn_t) (void);


### PR DESCRIPTION
1. Introducing 2 gdb plugin commands (Based on the commands in the odb gdb-wrapper):
	a. ompd parallel (Provides information about the current and enclosing parallel regions)
	b. ompd icv (Provides information about the current values of the Internal Control Variables
2. Adding --system to the pip command in libompd/gdb-plugin/CMakeLists.txt to avoid a build failure.
3. Invoking the python _read_string function with only the source address since the overflow
   error is handled in the caller. (ompdModule.c and ompd_callbacks.py). Other changes done to
   fix other _read_string() errors.
4. Avoiding the return of a stale handle in get_current_parallel_handle() in ompd_handles.py