### PR TITLE
Minor fix to correct "ompd bt on" 

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/frame_filter.py
+++ b/openmp/libompd/gdb-plugin/ompd/frame_filter.py
@@ -146,7 +146,7 @@ class FrameFilter():
 						if self.continue_to_master:
 							yield OmpdFrameDecoratorThread(x)
 						else:
-							yield OmpdFrameDecorator(x)
+							yield OmpdFrameDecorator(x, self.curr_task.task_handle)
 					else:
 						yield OmpdFrameDecorator(x, self.curr_task.task_handle)
 					break


### PR DESCRIPTION
This is a one line fix to correct the following issue with 'ompd bt on' followed by a 'bt'

Python Exception <type 'exceptions.TypeError'> __init__() takes exactly 3 arguments (2 given):