### PR TITLE
Fix for : Incorrect value provided by OMPD for thread-limit-var. 

### DIFF
--- a/openmp/runtime/src/ompd-specific.h
+++ b/openmp/runtime/src/ompd-specific.h
@@ -69,6 +69,7 @@ OMPD_ACCESS(kmp_internal_control_t, nproc) \
 OMPD_ACCESS(kmp_internal_control_t, proc_bind) \
 OMPD_ACCESS(kmp_internal_control_t, sched) \
 OMPD_ACCESS(kmp_internal_control_t, default_device) \
+OMPD_ACCESS(kmp_internal_control_t, thread_limit) \
 \
 OMPD_ACCESS(kmp_taskdata_t,       ompt_task_info) \
 OMPD_ACCESS(kmp_taskdata_t,       td_flags) \


### PR DESCRIPTION
The ICV value was incorrectly being read from __kmp_max_nth instead of from __kmp_threads[__kmp_gtid]->th.th_current_task->td_icvs.thread_limit. Fix provided by: nagajyothi.e@amd.com