### PR TITLE
Avoid the misleading -- Function 'ompd_tool_break' not defined -- message

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
@@ -25,10 +25,13 @@ class ompd_address_space(object):
 		self.threads = {}
 		self.states = None
 		self.icv_map = None
+		self.ompd_tool_test_bp = None
 		self.scope_map = {1:'global', 2:'address_space', 3:'thread', 4:'parallel', 5:'implicit_task', 6:'task'}
 		gdb.events.stop.connect(self.handle_stop_event)
 		self.new_thread_breakpoint = gdb.Breakpoint("ompd_bp_thread_begin", internal=True)
-		self.ompd_tool_test_bp = gdb.Breakpoint("ompd_tool_break", internal=True)
+		tool_break_symbol = gdb.lookup_global_symbol("ompd_tool_break")
+		if (tool_break_symbol is not None):
+			self.ompd_tool_test_bp = gdb.Breakpoint("ompd_tool_break", internal=True)
 	
 	def handle_stop_event(self, event):
 		"""Sets a breakpoint at different events, e.g. when a new OpenMP 
@@ -40,7 +43,7 @@ class ompd_address_space(object):
 				self.add_thread()
 				gdb.execute('continue')
 				return
-			elif(self.ompd_tool_test_bp in event.breakpoints):
+			elif (self.ompd_tool_test_bp is not None and self.ompd_tool_test_bp in event.breakpoints):
 				try:
 					self.compare_ompt_data()
 				except():


### PR DESCRIPTION
Changes to avoid the misleading message -- Function 'ompd_tool_break' not defined.
The changes are to first test if we can evaluate "omp_tool_break", and then place a breakpoint in that function only if it is found. 'lookup_symbol' might have been a neater choice for this, but it is not working. 