### PR TITLE
Specify -DLIBOMPD_PIP_FLAGS=--system during configuration, if required.

### DIFF
--- a/openmp/libompd/gdb-plugin/CMakeLists.txt
+++ b/openmp/libompd/gdb-plugin/CMakeLists.txt
@@ -4,7 +4,6 @@ set (CMAKE_MODULE_PATH
 )
 
 find_package (Python3 COMPONENTS Interpreter Development)
-
 include_directories (${OMPD_INCLUDE_PATH})
 include_directories (${LIBOMP_INCLUDE_DIR})
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python-module/loadompd.py
@@ -13,11 +12,12 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/python-module/loadompd.py
                    ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py -v bdist_wheel -b ${CMAKE_CURRENT_BINARY_DIR}/build -d ${CMAKE_CURRENT_BINARY_DIR}
                    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py clean --all
                    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_SOURCE_DIR}/ompd.egg-info
-                   COMMAND ${Python3_EXECUTABLE} -m pip install -U -t ${CMAKE_CURRENT_BINARY_DIR}/python-module --no-index --find-links=${CMAKE_CURRENT_BINARY_DIR} ompd
+                   COMMAND ${Python3_EXECUTABLE} -m pip install ${LIBOMPD_PIP_FLAGS} -U -t ${CMAKE_CURRENT_BINARY_DIR}/python-module --no-index
+                   --find-links=${CMAKE_CURRENT_BINARY_DIR} ompd
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(ompd_gdb_plugin ALL
                   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/python-module/loadompd.py
                   COMMENT "Building the OMPD GDB plugin")
 
-install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install -U -t ${CMAKE_INSTALL_PREFIX}/share/gdb/python/gdb --no-index --find-links=${CMAKE_CURRENT_BINARY_DIR} ompd)")
+install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -m pip install ${LIBOMPD_PIP_FLAGS} -U -t ${CMAKE_INSTALL_PREFIX}/share/gdb/python/gdb --no-index --find-links=${CMAKE_CURRENT_BINARY_DIR} ompd)")


### PR DESCRIPTION
While configuring cmake command to build OpenMP,
1. -DLIBOMPD_PIP_FLAGS="--system"  must be used on Ubuntu 18.04.3 LTS and lower
2.-DLIBOMPD_PIP_FLAGS="--system" must not be used on Ubuntu 19.04 LTS and higher