### PR TITLE
Incorrect values obtained for task_data and parallel_data with ompt_get_task_info() for ancestor_level > 0

### DIFF
--- a/openmp/runtime/src/ompt-specific.cpp
+++ b/openmp/runtime/src/ompt-specific.cpp
@@ -382,7 +382,7 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
       // lightweight teams are exhausted
       if (!lwt && taskdata) {
         // first try scheduling parent (for explicit task scheduling)
-        if (taskdata->ompt_task_info.scheduling_parent) {
+        if (taskdata->td_flags.tasktype == TASK_EXPLICIT && taskdata->ompt_task_info.scheduling_parent) {
           taskdata = taskdata->ompt_task_info.scheduling_parent;
         } else if (next_lwt) {
           lwt = next_lwt;


### PR DESCRIPTION
The ompt tests (nested_lwt.c, parallel_if0.c and serialized.c) in the ompd-tests branch fail currently since ompt_get_task_info() returns incorrect values for task_data and parallel_data for ancestor_levels > 0. 

This is related to the commit c1b4c5a79122ea3ba06f5ab6f4fa6433fa2283d8 :  Add information on scheduling parent for the master task in a parallel region. 

The proposed fix in __ompt_get_task_info_internal() is : 

While moving upwards through ancestor levels, set the taskdata at that level to ompt_task_info.scheduling_parent only if we are dealing with explicit tasks. 

