### PR TITLE
New test cases in different format

### DIFF
--- a/openmp/libompd/test/lit.cfg
+++ b/openmp/libompd/test/lit.cfg
@@ -72,6 +72,9 @@ config.substitutions.append(("%test_c_compiler", config.test_c_compiler))
 config.substitutions.append(("%gdb-run",
     "env OMP_DEBUG=enabled gdb -x " + config.ompd_obj_root + "/../gdb-plugin/python-module/ompd/__init__.py -x " \
     + config.ompd_test_src + "/test.cmd %t "))
+
+config.substitutions.append(("%gdb-test",
+    "env OMP_DEBUG=enabled gdb -x " + config.ompd_obj_root + "/../gdb-plugin/python-module/ompd/__init__.py "))
     
 config.substitutions.append(("%ompt-tool", 
     config.ompt_plugin))

--- a/openmp/libompd/test/openmp_examples/ompd_bt.c
+++ b/openmp/libompd/test/openmp_examples/ompd_bt.c
@@ -1,0 +1,51 @@
+// RUN: %gdb-compile 2>&1 | tee %t.compile
+// RUN: %gdb-test -x %S/ompd_bt.cmd %t 2>&1 | tee %t.out | FileCheck %s
+
+#include <omp.h>
+
+void subdomain(float *x, int istart, int ipoints)
+{
+  int i;
+
+  for (i = 0; i < ipoints; i++)
+    x[istart+i] = 123.456;
+}
+
+void sub(float *x, int npoints)
+{
+  int iam, nt, ipoints, istart;
+
+  #pragma omp parallel default(shared) private(iam,nt,ipoints,istart)
+  {
+    iam = omp_get_thread_num();
+    nt = omp_get_num_threads();
+    ipoints = npoints / nt; /* size of partition */
+    istart = iam * ipoints; /* starting array index */
+    if (iam == nt-1) /* last thread may do more */
+      ipoints = npoints - istart;
+    subdomain(x, istart, ipoints);
+  }
+}
+
+int main()
+{
+
+  omp_set_num_threads(5);
+  float array[10000];
+
+  sub(array, 10000);
+
+  return 0;
+}
+
+// CHECK: Loaded OMPD lib successfully!
+
+// CHECK: Enabled filter for "bt" output successfully.
+// CHECK-NOT: {{__kmp.*}}
+
+// CHECK: Disabled filter for "bt" output successfully
+// CHECK: {{__kmp.*}}
+
+// CHECK-NOT: Python Exception
+// CHECK-NOT: The program is not being run.
+// CHECK-NOT: No such file or directory

--- a/openmp/libompd/test/openmp_examples/ompd_bt.cmd
+++ b/openmp/libompd/test/openmp_examples/ompd_bt.cmd
@@ -1,0 +1,10 @@
+ompd init
+b ompd_bt.c:10
+c
+ompd bt on
+bt
+c
+ompd bt off
+bt
+d 3
+c

--- a/openmp/libompd/test/openmp_examples/ompd_icvs.c
+++ b/openmp/libompd/test/openmp_examples/ompd_icvs.c
@@ -1,0 +1,73 @@
+// RUN: %gdb-compile 2>&1 | tee %t.compile
+// RUN: %gdb-test -x %S/ompd_icvs.cmd %t 2>&1 | tee %t.out | FileCheck %s
+
+#include <stdio.h>
+#include <omp.h>
+int main (void)
+{
+  omp_set_max_active_levels(3);
+  omp_set_dynamic(0);
+  omp_set_num_threads(9);
+  #pragma omp parallel
+  {
+    omp_set_num_threads(5);
+    #pragma omp parallel
+    {
+      #pragma omp single
+      {
+        /*
+        * If OMP_NUM_THREADS=2,3 was set, the following should print:
+        * Inner: num_thds=3
+        * Inner: num_thds=3
+        *
+        * If nesting is not supported, the following should print:
+        * Inner: num_thds=1
+        * Inner: num_thds=1
+        */
+        printf ("Inner: num_thds=%d\n", omp_get_num_threads());
+      }
+    }
+    #pragma omp barrier
+    omp_set_max_active_levels(0);
+    #pragma omp parallel
+    {
+      #pragma omp single
+      {
+        /*
+        * Even if OMP_NUM_THREADS=2,3 was set, the following should
+        * print, because nesting is disabled:
+        * Inner: num_thds=1
+        * Inner: num_thds=1
+        */
+        printf ("Inner: num_thds=%d\n", omp_get_num_threads());
+      }
+    }
+    #pragma omp barrier
+    #pragma omp single
+    {
+      /*
+      * If OMP_NUM_THREADS=2,3 was set, the following should print:
+      * Outer: num_thds=2
+      */
+      printf ("Outer: num_thds=%d\n", omp_get_num_threads());
+    }
+  }
+  return 0;
+}
+// CHECK: Loaded OMPD lib successfully!
+
+// CHECK: levels-var                      parallel                   2
+// CHECK: active-levels-var               parallel                   2
+// CHECK: ompd-team-size-var              parallel                   5
+
+// CHECK: levels-var                      parallel                   2
+// CHECK: active-levels-var               parallel                   1
+// CHECK: ompd-team-size-var              parallel                   1
+
+// CHECK: levels-var                      parallel                   1
+// CHECK: active-levels-var               parallel                   1
+// CHECK: ompd-team-size-var              parallel                   9
+
+// CHECK-NOT: Python Exception
+// CHECK-NOT: The program is not being run.
+// CHECK-NOT: No such file or directory

--- a/openmp/libompd/test/openmp_examples/ompd_icvs.cmd
+++ b/openmp/libompd/test/openmp_examples/ompd_icvs.cmd
@@ -1,0 +1,14 @@
+ompd init
+b ompd_icvs.c:27
+b ompd_icvs.c:42
+b ompd_icvs.c:52
+c
+ompd icvs
+d 3
+c
+ompd icvs
+d 4
+c
+ompd icvs
+d 5
+c

--- a/openmp/libompd/test/openmp_examples/ompd_parallel.c
+++ b/openmp/libompd/test/openmp_examples/ompd_parallel.c
@@ -1,0 +1,48 @@
+// RUN: %gdb-compile 2>&1 | tee %t.compile
+// RUN: %gdb-test -x %S/ompd_parallel.cmd %t 2>&1 | tee %t.out | FileCheck %s
+
+#include <stdio.h>
+#include <omp.h>
+
+int main ()
+{
+  omp_set_max_active_levels(3);
+  omp_set_num_threads(7);
+  #pragma omp parallel
+  {
+    omp_set_num_threads(5);
+    #pragma omp parallel
+    {
+      omp_set_num_threads(3);
+      #pragma omp parallel
+      {
+        printf ("In nested level:3, team size = %d.\n", omp_get_num_threads());
+      }
+
+      printf ("In nested level:2, team size = %d.\n", omp_get_num_threads());
+    }
+    printf ("In nested level:1, team size = %d.\n", omp_get_num_threads());
+  }
+
+  return 0;
+}
+
+// CHECK: Loaded OMPD lib successfully!
+// CHECK: Nesting Level 3: Team Size: 3
+// CHECK: ompd_parallel.c{{[ ]*}}:17
+// CHECK: Nesting Level 2: Team Size: 5
+// CHECK: ompd_parallel.c{{[ ]*}}:14
+// CHECK: Nesting Level 1: Team Size: 7
+// CHECK: ompd_parallel.c{{[ ]*}}:11
+
+// CHECK: Nesting Level 2: Team Size: 5
+// CHECK: ompd_parallel.c{{[ ]*}}:14
+// CHECK: Nesting Level 1: Team Size: 7
+// CHECK: ompd_parallel.c{{[ ]*}}:11
+
+// CHECK: Nesting Level 1: Team Size: 7
+// CHECK: ompd_parallel.c{{[ ]*}}:11
+
+// CHECK-NOT: Python Exception
+// CHECK-NOT: The program is not being run.
+// CHECK-NOT: No such file or directory

--- a/openmp/libompd/test/openmp_examples/ompd_parallel.cmd
+++ b/openmp/libompd/test/openmp_examples/ompd_parallel.cmd
@@ -1,0 +1,14 @@
+ompd init
+b ompd_parallel.c:19
+b ompd_parallel.c:22
+b ompd_parallel.c:24
+c
+ompd parallel
+d 3
+c
+ompd parallel
+d 4
+c
+ompd parallel
+d 5
+c


### PR DESCRIPTION
Instead of depending on OMPT , this patch validates the commands like "ompd bt" using FILECHECK.
Issue: https://github.com/OpenMPToolsInterface/llvm-project/issues/19
