### PR TITLE
The ICV "bind-var" needs to be displayed as a list if applicable

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd.py
@@ -183,7 +183,7 @@ class ompd_icvs(gdb.Command):
 				else:
 					raise ValueError("Invalid scope")
 
-				if (icv_name == "nthreads-var"):
+				if (icv_name == "nthreads-var" or icv_name == "bind-var"):
 					icv_value = ompdModule.call_ompd_get_icv_from_scope(
 						    handle, scope, addr_space.icv_map[icv_name][0])
 					if icv_value is None:

--- a/openmp/runtime/src/ompd-specific.h
+++ b/openmp/runtime/src/ompd-specific.h
@@ -84,6 +84,9 @@ OMPD_ACCESS(kmp_team_p,           t) \
 OMPD_ACCESS(kmp_nested_nthreads_t, used) \
 OMPD_ACCESS(kmp_nested_nthreads_t, nth) \
 \
+OMPD_ACCESS(kmp_nested_proc_bind_t, used) \
+OMPD_ACCESS(kmp_nested_proc_bind_t, bind_types) \
+\
 OMPD_ACCESS(ompt_task_info_t,     frame) \
 OMPD_ACCESS(ompt_task_info_t,     scheduling_parent) \
 OMPD_ACCESS(ompt_task_info_t,     task_data) \
@@ -144,6 +147,8 @@ OMPD_SIZEOF(__kmp_tool) \
 OMPD_SIZEOF(ompd_state) \
 OMPD_SIZEOF(kmp_nested_nthreads_t) \
 OMPD_SIZEOF(__kmp_nested_nth) \
+OMPD_SIZEOF(kmp_nested_proc_bind_t) \
+OMPD_SIZEOF(__kmp_nested_proc_bind) \
 OMPD_SIZEOF(int) \
 OMPD_SIZEOF(char) \
 OMPD_SIZEOF(__kmp_gtid) \


### PR DESCRIPTION
Currently, the ompd API ompd_get_icv_from_scope() (through ompd_get_proc_bind()) only returns the first element of the bind-var list. (Even if bind-var is a list with more than 1 element). This needs to be corrected to display the elements of the list from  what is corresponding to the current nesting level to "__kmp_nested_proc_bind.used".  (Similar to what gets displayed with the nthreads-var). 

The proposed implementation is on the lines of the implementation for retrieving the value of nthreads-var. It includes a call to ompd_get_icv_string_from_scope(). 