### PR TITLE
ICV names as per OpenMP 5.1 and support for tool-verbose-init-var ICV

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/frame_filter.py
+++ b/openmp/libompd/gdb-plugin/ompd/frame_filter.py
@@ -32,7 +32,7 @@ class OmpdFrameDecorator(FrameDecorator):
 		if self.curr_task_handle is None:
 			return name
 		
-		icv_value = ompdModule.call_ompd_get_icv_from_scope(self.curr_task_handle, ompd.icv_map['ompd-implicit-var'][1], ompd.icv_map['ompd-implicit-var'][0])
+		icv_value = ompdModule.call_ompd_get_icv_from_scope(self.curr_task_handle, ompd.icv_map['implicit-task-var'][1], ompd.icv_map['implicit-task-var'][0])
 		if icv_value == 0:
 			name = '@thread %i: %s "#pragma omp task"' % (gdb.selected_thread().num, name)
 		elif icv_value == 1:

--- a/openmp/libompd/gdb-plugin/ompd/ompd.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd.py
@@ -136,8 +136,8 @@ class ompd_parallel_region(gdb.Command):
 			if nest_level == 0:
 				break
 			team_size = ompdModule.call_ompd_get_icv_from_scope(curr_parallel_handle, \
-				    addr_space.icv_map['ompd-team-size-var'][1], \
-				    addr_space.icv_map['ompd-team-size-var'][0])
+				    addr_space.icv_map['team-size-var'][1], \
+				    addr_space.icv_map['team-size-var'][0])
 			print ("")
 			print ("Parallel Region: Nesting Level %d: Team Size: %d" % (nest_level, team_size))
 			print ("================================================")
@@ -193,7 +193,8 @@ class ompd_icvs(gdb.Command):
 					else:
 						print('%-31s %-26s %d' % (icv_name, ompd_scope_map[scope], icv_value))
 
-				elif (icv_name == "affinity-format-var" or icv_name == "tool-libraries-var" ):
+				elif (icv_name == "affinity-format-var" or \
+                                         icv_name == "tool-libraries-var" or icv_name == "tool-verbose-init-var"):
 					icv_string = ompdModule.call_ompd_get_icv_string_from_scope( \
 						     handle, scope, addr_space.icv_map[icv_name][0])
 					print('%-31s %-26s %s' % (icv_name, ompd_scope_map[scope], icv_string))

--- a/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
@@ -106,9 +106,9 @@ class ompd_address_space(object):
 				print('OMPT-OMPD mismatch: ompt_wait_id (%d) does not match OMPD wait id (%d)!' % (ompt_wait_id, ompd_wait_id))
 		
 		# compare thread id
-		if 'omp_thread_num' in field_names and 'ompd-thread-num-var' in self.icv_map:
+		if 'omp_thread_num' in field_names and 'thread-num-var' in self.icv_map:
 			ompt_thread_num = thread_data['omp_thread_num']
-			icv_value = ompdModule.call_ompd_get_icv_from_scope(curr_thread.thread_handle, self.icv_map['ompd-thread-num-var'][1], self.icv_map['ompd-thread-num-var'][0])
+			icv_value = ompdModule.call_ompd_get_icv_from_scope(curr_thread.thread_handle, self.icv_map['thread-num-var'][1], self.icv_map['thread-num-var'][0])
 			if ompt_thread_num != icv_value:
 				print('OMPT-OMPD mismatch: omp_thread_num (%d) does not match OMPD thread num according to ICVs (%d)!' % (ompt_thread_num, icv_value))
 		
@@ -120,9 +120,9 @@ class ompd_address_space(object):
 				print('OMPT-OMPD mismatch: value of ompt_thread_data (%d) does not match that of OMPD data union (%d)!' % (ompt_thread_data, ompd_value))
 		
 		# compare number of threads
-		if 'omp_num_threads' in field_names and 'ompd-team-size-var' in self.icv_map:
+		if 'omp_num_threads' in field_names and 'team-size-var' in self.icv_map:
 			ompt_num_threads = thread_data['omp_num_threads']
-			icv_value = ompdModule.call_ompd_get_icv_from_scope(curr_thread.get_current_parallel_handle(), self.icv_map['ompd-team-size-var'][1], self.icv_map['ompd-team-size-var'][0])
+			icv_value = ompdModule.call_ompd_get_icv_from_scope(curr_thread.get_current_parallel_handle(), self.icv_map['team-size-var'][1], self.icv_map['team-size-var'][0])
 			if ompt_num_threads != icv_value:
 				print('OMPT-OMPD mismatch: omp_num_threads (%d) does not match OMPD num threads according to ICVs (%d)!' % (ompt_num_threads, icv_value))
 		
@@ -172,10 +172,10 @@ class ompd_address_space(object):
 				print('OMPT-OMPD mismatch: ompt_parallel (%d) does not match OMPD parallel according to ICVs (%d)!' % (ompt_parallel, icv_value))
 		
 		# compare omp_final
-		if 'omp_final' in field_names and 'ompd-final-var' in self.icv_map:
+		if 'omp_final' in field_names and 'final-task-var' in self.icv_map:
 			ompt_final = thread_data['omp_final']
 			current_task_handle = curr_thread.get_current_task_handle()
-			icv_value = ompdModule.call_ompd_get_icv_from_scope(current_task_handle, self.icv_map['ompd-final-var'][1], self.icv_map['ompd-final-var'][0])
+			icv_value = ompdModule.call_ompd_get_icv_from_scope(current_task_handle, self.icv_map['final-task-var'][1], self.icv_map['final-task-var'][0])
 			if icv_value != ompt_final:
 				print('OMPT-OMPD mismatch: omp_final (%d) does not match OMPD final according to ICVs (%d)!' % (ompt_final, icv_value))
 		

--- a/openmp/libompd/src/omp-icv.cpp
+++ b/openmp/libompd/src/omp-icv.cpp
@@ -15,6 +15,10 @@
 #include "ompd-private.h"
 #include "TargetValue.h"
 
+/* The ICVs ompd-final-var and ompd-implicit-var below are for backward
+ * compatibility with 5.0.
+ */
+
 #define FOREACH_OMPD_ICV(macro)                                                \
     macro (dyn_var, "dyn-var", ompd_scope_thread, 0)                           \
     macro (stacksize_var, "stacksize-var", ompd_scope_address_space, 0)        \
@@ -34,10 +38,18 @@
     macro (max_active_levels_var, "max-active-levels-var", ompd_scope_task, 0) \
     macro (bind_var, "bind-var", ompd_scope_task, 0)                           \
     macro (num_procs_var, "num-procs-var", ompd_scope_address_space, 0)        \
+    macro (ompd_num_procs_var, "ompd-num-procs-var", ompd_scope_address_space, 0)        \
     macro (thread_num_var, "thread-num-var", ompd_scope_thread, 1)             \
+    macro (ompd_thread_num_var, "ompd-thread-num-var", ompd_scope_thread, 1)   \
     macro (final_var, "final-task-var", ompd_scope_task, 0)                    \
+    macro (ompd_final_var, "ompd-final-var", ompd_scope_task, 0)               \
+    macro (ompd_final_task_var, "ompd-final-task-var", ompd_scope_task, 0)     \
     macro (implicit_var, "implicit-task-var", ompd_scope_task, 0)              \
+    macro (ompd_implicit_var, "ompd-implicit-var", ompd_scope_task, 0)         \
+    macro (ompd_implicit_task_var, "ompd-implicit-task-var", ompd_scope_task, 0)         \
     macro (team_size_var, "team-size-var", ompd_scope_parallel, 1)             \
+    macro (ompd_team_size_var, "ompd-team-size-var", ompd_scope_parallel, 1)   \
+
 
 void __ompd_init_icvs(const ompd_callbacks_t *table) {
   callbacks = table;
@@ -1085,14 +1097,21 @@ ompd_rc_t ompd_get_icv_from_scope(void *handle, ompd_scope_t scope,
       case ompd_icv_bind_var:
         return ompd_get_proc_bind((ompd_task_handle_t*)handle, icv_value);
       case ompd_icv_num_procs_var:
+      case ompd_icv_ompd_num_procs_var:
         return ompd_get_num_procs((ompd_address_space_handle_t*)handle, icv_value);
       case ompd_icv_thread_num_var:
+      case ompd_icv_ompd_thread_num_var:
         return ompd_get_thread_num((ompd_thread_handle_t*)handle, icv_value);
       case ompd_icv_final_var:
+      case ompd_icv_ompd_final_var:
+      case ompd_icv_ompd_final_task_var:
         return ompd_in_final((ompd_task_handle_t*)handle, icv_value);
       case ompd_icv_implicit_var:
+      case ompd_icv_ompd_implicit_var:
+      case ompd_icv_ompd_implicit_task_var:
         return ompd_is_implicit((ompd_task_handle_t*)handle, icv_value);
       case ompd_icv_team_size_var:
+      case ompd_icv_ompd_team_size_var:
         return ompd_get_num_threads((ompd_parallel_handle_t*)handle, icv_value);
       default:
         return ompd_rc_unsupported;

--- a/openmp/libompd/test/openmp_examples/ompd_icvs.c
+++ b/openmp/libompd/test/openmp_examples/ompd_icvs.c
@@ -58,15 +58,15 @@ int main (void)
 
 // CHECK: levels-var                      parallel                   2
 // CHECK: active-levels-var               parallel                   2
-// CHECK: ompd-team-size-var              parallel                   5
+// CHECK: team-size-var                   parallel                   5
 
 // CHECK: levels-var                      parallel                   2
 // CHECK: active-levels-var               parallel                   1
-// CHECK: ompd-team-size-var              parallel                   1
+// CHECK: team-size-var                   parallel                   1
 
 // CHECK: levels-var                      parallel                   1
 // CHECK: active-levels-var               parallel                   1
-// CHECK: ompd-team-size-var              parallel                   9
+// CHECK: team-size-var                   parallel                   9
 
 // CHECK-NOT: Python Exception
 // CHECK-NOT: The program is not being run.

--- a/openmp/runtime/src/kmp_settings.cpp
+++ b/openmp/runtime/src/kmp_settings.cpp
@@ -4727,7 +4727,7 @@ static void __kmp_stg_print_omp_tool_libraries(kmp_str_buf_t *buffer,
   }
 } // __kmp_stg_print_omp_tool_libraries
 
-static char *__kmp_tool_verbose_init = NULL;
+char *__kmp_tool_verbose_init = NULL;
 
 static void __kmp_stg_parse_omp_tool_verbose_init(char const *name,
                                                   char const *value, void *data) {

--- a/openmp/runtime/src/ompd-specific.h
+++ b/openmp/runtime/src/ompd-specific.h
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 extern char *ompd_env_block;
 extern ompd_size_t ompd_env_block_size;
+extern char *__kmp_tool_verbose_init;
 #ifdef  __cplusplus
 } /* extern "C" */
 #endif
@@ -146,6 +147,7 @@ OMPD_SIZEOF(__kmp_max_task_priority) \
 OMPD_SIZEOF(__kmp_display_affinity) \
 OMPD_SIZEOF(__kmp_affinity_format) \
 OMPD_SIZEOF(__kmp_tool_libraries) \
+OMPD_SIZEOF(__kmp_tool_verbose_init) \
 OMPD_SIZEOF(__kmp_tool) \
 OMPD_SIZEOF(ompd_state) \
 OMPD_SIZEOF(kmp_nested_nthreads_t) \


### PR DESCRIPTION
Changes to incorporate the new ICV names as per TR9 (sans the ompd prefix), some cleanup and changes to support the ompd retrieval of the tool-verbose-init-var ICV.