### PR TITLE
Fixing API's return code to be valid asper std doc

### DIFF
--- a/openmp/libompd/gdb-plugin/ompdModule.c
+++ b/openmp/libompd/gdb-plugin/ompdModule.c
@@ -542,7 +542,7 @@ ompd_rc_t _read (
 		}
 		Py_ssize_t retSize = PyByteArray_Size(retArray);
 		const char* strBuf = PyByteArray_AsString(retArray);
-		if(retSize != nbytes) {
+		if((unsigned int)retSize != nbytes) {
 			return ompd_rc_error;
 		}
 		memcpy(buffer, strBuf, nbytes);
@@ -574,7 +574,7 @@ ompd_rc_t _read_string (
 	}
 	Py_ssize_t retSize;
 	const char* strbuffer = PyUnicode_AsUTF8AndSize(retString, &retSize);
-	if(retSize >= nbytes) {
+	if((unsigned int)retSize >= nbytes) {
 		retVal = ompd_rc_incomplete;
 	}
  	strncpy(buffer, strbuffer, nbytes);

--- a/openmp/libompd/gdb-plugin/ompdModule.c
+++ b/openmp/libompd/gdb-plugin/ompdModule.c
@@ -694,7 +694,7 @@ static PyObject* call_ompd_initialize(PyObject* self, PyObject* noargs)
 		};
 	
 	ompd_rc_t (*my_ompd_init)(ompd_word_t version, ompd_callbacks_t*) = dlsym(ompd_library, "ompd_initialize");
-	ompd_rc_t returnInit = my_ompd_init(42, &table);
+	ompd_rc_t returnInit = my_ompd_init(201811, &table);
 	if(returnInit != ompd_rc_ok) {
 		_printf("An error occurred when calling ompd_initialize! Error code: %d", returnInit);
 	}
@@ -961,7 +961,7 @@ static PyObject* call_ompd_get_icv_from_scope(PyObject* self, PyObject* args) {
 	ompd_rc_t retVal = ompd_get_icv_from_scope(addrSpaceHandle, scope, icvId, &icvValue);
 	
 	if(retVal != ompd_rc_ok) {
-                if (retVal != ompd_rc_incompatible) {
+                if (retVal != ompd_rc_incomplete) {
 		    _printf("An error occurred when calling ompd_get_icv_from_scope(%i, %i): Error code: %d", scope, icvId, retVal);
                 }
 		return Py_None;

--- a/openmp/libompd/src/omp-debug.cpp
+++ b/openmp/libompd/src/omp-debug.cpp
@@ -33,6 +33,9 @@
 
 ompd_device_type_sizes_t type_sizes;
 uint64_t ompd_state;
+ompd_rc_t ompd_get_num_threads(
+    ompd_parallel_handle_t *parallel_handle, /* IN: OpenMP parallel handle */
+    ompd_word_t *val     /* OUT: number of threads */);
 
 /* --- OMPD functions ------------------------------------------------------- */
 
@@ -40,6 +43,11 @@ uint64_t ompd_state;
 
 ompd_rc_t ompd_initialize(ompd_word_t version, const ompd_callbacks_t *table) {
   ompd_rc_t ret = table ? ompd_rc_ok : ompd_rc_bad_input;
+  ompd_word_t ompd_version;
+
+  ompd_get_api_version(&ompd_version);
+  if (version != ompd_version)
+    return ompd_rc_unsupported;
   callbacks = table;
   TValue::callbacks = table;
   __ompd_init_icvs(table);
@@ -76,6 +84,7 @@ ompd_process_initialize(ompd_address_space_context_t
     return ret;
   if (!handle)
     return ompd_rc_error;
+
   (*handle)->context = context;
   (*handle)->kind = OMPD_DEVICE_KIND_HOST;
 
@@ -88,6 +97,9 @@ ompd_get_omp_version(ompd_address_space_handle_t
                      ompd_word_t *version) {
   if (!address_space)
     return ompd_rc_stale_handle;
+  if (!version)
+    return ompd_rc_bad_input;
+
   ompd_address_space_context_t *context = address_space->context;
   ompd_rc_t ret;
 
@@ -109,6 +121,8 @@ ompd_rc_t ompd_get_omp_version_string(
         *address_space, /* IN: handle for the address space */
     const char **string) {
   if (!address_space)
+    return ompd_rc_stale_handle;
+  if (!string)
     return ompd_rc_bad_input;
   static const char *omp_version = "";
   *string = omp_version;
@@ -202,6 +216,13 @@ ompd_rc_t ompd_get_thread_in_parallel(
     return ompd_rc_callback_error;
   }
 
+  ompd_word_t team_size_var;
+  ret = ompd_get_num_threads (parallel_handle, &team_size_var);
+  if (ret != ompd_rc_ok)
+    return ret;
+  if (thread_num < 0 || thread_num >= team_size_var)
+    return ompd_rc_bad_input;
+
   ompd_address_t taddr={OMPD_SEGMENT_UNSPECIFIED,0};
 
   if (parallel_handle->ah->kind == OMPD_DEVICE_KIND_CUDA) {
@@ -286,6 +307,8 @@ ompd_rc_t ompd_thread_handle_compare(ompd_thread_handle_t *thread_handle_1,
     return ompd_rc_stale_handle;
   if (!thread_handle_2)
     return ompd_rc_stale_handle;
+  if (!cmp_value)
+    return ompd_rc_bad_input;
   if (thread_handle_1->ah->kind != thread_handle_2->ah->kind)
     return ompd_rc_bad_input;
   *cmp_value = thread_handle_1->th.address - thread_handle_2->th.address;
@@ -667,6 +690,8 @@ ompd_parallel_handle_compare(ompd_parallel_handle_t *parallel_handle_1,
     return ompd_rc_stale_handle;
   if (!parallel_handle_2)
     return ompd_rc_stale_handle;
+  if (!cmp_value)
+    return ompd_rc_bad_input;
   if (parallel_handle_1->ah->kind != parallel_handle_2->ah->kind)
     return ompd_rc_bad_input;
   if (parallel_handle_1->ah->kind == OMPD_DEVICE_KIND_HOST) {
@@ -748,15 +773,16 @@ ompd_rc_t ompd_get_generating_task_handle(
     ompd_task_handle_t *task_handle,        /* IN: OpenMP task handle */
     ompd_task_handle_t **parent_task_handle /* OUT: OpenMP task handle */
     ) {
+  if (!task_handle)
+    return ompd_rc_stale_handle;
+  if (!task_handle->ah)
+    return ompd_rc_stale_handle;
+
   // Generating and Scheduling task are the same on cuda?
   if (task_handle->ah->kind == OMPD_DEVICE_KIND_CUDA) {
     return ompd_get_scheduling_task_handle(task_handle, parent_task_handle);
   }
 
-  if (!task_handle)
-    return ompd_rc_stale_handle;
-  if (!task_handle->ah)
-    return ompd_rc_stale_handle;
   ompd_address_space_context_t *context = task_handle->ah->context;
   if (!context)
     return ompd_rc_stale_handle;
@@ -889,6 +915,13 @@ ompd_rc_t ompd_get_task_in_parallel(
   }
 
   ompd_rc_t ret;
+  ompd_word_t team_size_var;
+  ret = ompd_get_num_threads (parallel_handle, &team_size_var);
+  if (ret != ompd_rc_ok)
+    return ret;
+  if (thread_num < 0 || thread_num >= team_size_var)
+    return ompd_rc_bad_input;
+
   ompd_address_t taddr={OMPD_SEGMENT_UNSPECIFIED,0};
 
   if (parallel_handle->ah->kind == OMPD_DEVICE_KIND_CUDA) {
@@ -942,6 +975,8 @@ ompd_rc_t ompd_task_handle_compare(ompd_task_handle_t *task_handle_1,
     return ompd_rc_stale_handle;
   if (!task_handle_2)
     return ompd_rc_stale_handle;
+  if (!cmp_value)
+    return ompd_rc_bad_input;
   if (task_handle_1->ah->kind != task_handle_2->ah->kind)
     return ompd_rc_bad_input;
   if (task_handle_1->th.address - task_handle_2->th.address ||
@@ -1109,6 +1144,8 @@ ompd_rc_t ompd_get_thread_id(
     ompd_thread_handle_t *thread_handle, /* IN: OpenMP thread handle*/
     ompd_thread_id_t kind, ompd_size_t sizeof_thread_id, void *thread_id) {
   if (kind != OMPD_THREAD_ID_PTHREAD && kind != OMPD_THREAD_ID_CUDALOGICAL)
+    return ompd_rc_unsupported;
+  if (!thread_id)
     return ompd_rc_bad_input;
   if (!thread_handle)
     return ompd_rc_stale_handle;
@@ -1195,6 +1232,8 @@ ompd_rc_t ompd_get_state(
     return ompd_rc_stale_handle;
   if (!thread_handle->ah)
     return ompd_rc_stale_handle;
+  if (!state)
+    return ompd_rc_bad_input;
   ompd_address_space_context_t *context = thread_handle->ah->context;
   if (!context)
     return ompd_rc_stale_handle;
@@ -1230,10 +1269,11 @@ ompd_rc_t ompd_get_state(
             .getValue(*state);
     if (ret != ompd_rc_ok)
       return ret;
-    ret = ompt_thread_info
-              .access("wait_id") /*__kmp_threads[t]->th.ompt_thread_info.state*/
-              .castBase()
-              .getValue(*wait_id);
+    if (wait_id)
+      ret = ompt_thread_info
+             .access("wait_id") /*__kmp_threads[t]->th.ompt_thread_info.state*/
+             .castBase()
+             .getValue(*wait_id);
   }
   return ret;
 }
@@ -1253,6 +1293,8 @@ ompd_rc_t ompd_get_task_frame(
     return ompd_rc_stale_handle;
   if (!task_handle->ah)
     return ompd_rc_stale_handle;
+  if (!exit_frame || !enter_frame)
+    return ompd_rc_bad_input;
   ompd_address_space_context_t *context = task_handle->ah->context;
   if (!context)
     return ompd_rc_stale_handle;
@@ -1306,6 +1348,8 @@ ompd_rc_t ompd_get_task_function(
     return ompd_rc_stale_handle;
   if (!task_handle->ah)
     return ompd_rc_stale_handle;
+  if (!task_addr)
+    return ompd_rc_bad_input;
   ompd_address_space_context_t *context = task_handle->ah->context;
   if (!context)
     return ompd_rc_stale_handle;
@@ -1377,6 +1421,9 @@ ompd_rc_t ompd_get_task_function(
 /* ------- OMPD Version and Compatibility Information ----------------------- */
 
 ompd_rc_t ompd_get_api_version(ompd_word_t *version) {
+  if (!version)
+    return ompd_rc_bad_input;
+
   *version = OMPD_VERSION;
   return ompd_rc_ok;
 }
@@ -1384,6 +1431,9 @@ ompd_rc_t ompd_get_api_version(ompd_word_t *version) {
 ompd_rc_t
 ompd_get_version_string(const char **string /* OUT: OMPD version string */
                             ) {
+  if (!string)
+    return ompd_rc_bad_input;
+
   static const char version_string[] =
       "LLVM OpenMP " STR(OMPD_IMPLEMENTS_OPENMP) "." STR(
           OMPD_IMPLEMENTS_OPENMP_SUBVERSION) " Debugging Library implmenting "

--- a/openmp/libompd/src/omp-debug.cpp
+++ b/openmp/libompd/src/omp-debug.cpp
@@ -979,7 +979,7 @@ ompd_get_thread_handle(ompd_address_space_handle_t
   int tId;
 
   if (kind == OMPD_THREAD_ID_CUDALOGICAL) {
-    ompd_cudathread_coord_t *p = (ompd_cudathread_coord_t *)thread_id;
+    const ompd_cudathread_coord_t *p = (const ompd_cudathread_coord_t *)thread_id;
 
     // omptarget_nvptx_threadPrivateContext->topTaskDescr[p->threadIdx.x]
     TValue th = TValue(context, tcontext,

--- a/openmp/libompd/src/omp-icv.cpp
+++ b/openmp/libompd/src/omp-icv.cpp
@@ -109,7 +109,7 @@ static ompd_rc_t ompd_enumerate_icvs_cuda(ompd_icv_id_t current,
   if (ret != ompd_rc_ok) {
     return ret;
   }
-  std::strcpy((char*)*next_icv_name, ompd_icv_string_values[*next_id]);
+  std::strcpy(const_cast<char*>(*next_icv_name), ompd_icv_string_values[*next_id]);
 
   *next_scope = ompd_icv_scope_values[*next_id];
 
@@ -149,7 +149,7 @@ ompd_rc_t ompd_enumerate_icvs(ompd_address_space_handle_t *handle,
   if (ret != ompd_rc_ok) {
     return ret;
   }
-  std::strcpy((char*)*next_icv_name, ompd_icv_string_values[*next_id]);
+  std::strcpy(const_cast<char*>(*next_icv_name), ompd_icv_string_values[*next_id]);
 
   *next_scope = ompd_icv_scope_values[*next_id];
 

--- a/openmp/libompd/src/omp-icv.cpp
+++ b/openmp/libompd/src/omp-icv.cpp
@@ -133,6 +133,9 @@ ompd_rc_t ompd_enumerate_icvs(ompd_address_space_handle_t *handle,
   if (!handle) {
     return ompd_rc_stale_handle;
   }
+  if (!next_id || !next_icv_name || !next_scope || !more) {
+	return ompd_rc_bad_input;
+  }
   if (handle->kind == OMPD_DEVICE_KIND_CUDA) {
     return ompd_enumerate_icvs_cuda(current, next_id, next_icv_name,
                                     next_scope, more);
@@ -367,10 +370,10 @@ static ompd_rc_t ompd_get_nthreads(
   *nthreads_var_val = nproc;
   /* If the nthreads-var is a list with more than one element, then the value of
      this ICV cannot be represented by an integer type. In this case,
-     ompd_rc_incompatible is returned. The tool can check the return value and
+     ompd_rc_incomplete is returned. The tool can check the return value and
      can choose to invoke ompd_get_icv_string_from_scope() if needed. */
   if (current_nesting_level < used - 1) {
-    return ompd_rc_incompatible;
+    return ompd_rc_incomplete;
   }
   return ompd_rc_ok;
 }
@@ -867,10 +870,10 @@ ompd_get_proc_bind(ompd_task_handle_t *task_handle, /* IN: OpenMP task handle */
   *bind = proc_bind;
   /* If bind-var is a list with more than one element, then the value of
      this ICV cannot be represented by an integer type. In this case,
-     ompd_rc_incompatible is returned. The tool can check the return value and
+     ompd_rc_incomplete is returned. The tool can check the return value and
      can choose to invoke ompd_get_icv_string_from_scope() if needed. */
   if (current_nesting_level < used - 1) {
-    return ompd_rc_incompatible;
+    return ompd_rc_incomplete
   }
   return ompd_rc_ok;
 }
@@ -971,7 +974,7 @@ ompd_is_implicit(ompd_task_handle_t *task_handle, /* IN: OpenMP task handle*/
   return ret;
 } 
 
-static ompd_rc_t
+ompd_rc_t
 ompd_get_num_threads(ompd_parallel_handle_t
                         *parallel_handle, /* IN: OpenMP parallel handle */
                      ompd_word_t *val     /* OUT: number of threads */


### PR DESCRIPTION
1, "ompd_initialize" should be called with valid OMPD "version", as of now supported libompd version is "201811(OMPD_VERSION)"
2, Other minor changes to check sanity for arguments to return proper return code.