### PR TITLE
Let gdb to "continue" after 1st break point

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
+++ b/openmp/libompd/gdb-plugin/ompd/ompd_address_space.py
@@ -46,6 +46,7 @@ class ompd_address_space(object):
 			elif (self.ompd_tool_test_bp is not None and self.ompd_tool_test_bp in event.breakpoints):
 				try:
 					self.compare_ompt_data()
+					gdb.execute('continue')
 				except():
 					traceback.print_exc()
 		elif (isinstance(event, gdb.SignalEvent)):

--- a/openmp/libompd/test/ompt_plugin.h
+++ b/openmp/libompd/test/ompt_plugin.h
@@ -169,7 +169,7 @@ void collectTaskData(omp_t_data_t * data)
 	data->omp_parallel = omp_in_parallel();
 	data->omp_final = omp_in_final();
 	data->omp_dynamic = omp_get_dynamic();
-	data->omp_nested = omp_get_nested();
+	data->omp_nested = omp_get_max_active_levels();
 	data->omp_max_active_levels = omp_get_max_active_levels();
 	omp_get_schedule(&(data->omp_kind), &(data->omp_modifier));
 	data->omp_proc_bind = omp_get_proc_bind();

--- a/openmp/libompd/test/ompt_plugin.h
+++ b/openmp/libompd/test/ompt_plugin.h
@@ -169,7 +169,7 @@ void collectTaskData(omp_t_data_t * data)
 	data->omp_parallel = omp_in_parallel();
 	data->omp_final = omp_in_final();
 	data->omp_dynamic = omp_get_dynamic();
-	data->omp_nested = omp_get_max_active_levels();
+	data->omp_nested = omp_get_max_active_levels()>1;
 	data->omp_max_active_levels = omp_get_max_active_levels();
 	omp_get_schedule(&(data->omp_kind), &(data->omp_modifier));
 	data->omp_proc_bind = omp_get_proc_bind();


### PR DESCRIPTION
When test cases are verified through "ompd_tool_test", gdb stops at first breakpoint/event. This patch will allow the program to continue till end of execution.