### PR TITLE
Correct out of source build failure due to the inclusion of kmp.h in omp-icv.cpp

### DIFF
--- a/openmp/libompd/src/CMakeLists.txt
+++ b/openmp/libompd/src/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 include_directories (
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${LIBOMP_INCLUDE_DIR}
+        ${LIBOMP_SRC_DIR}
 )
 
 INSTALL( TARGETS ompd

--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -390,3 +390,4 @@ add_subdirectory(test)
 # make these variables available for tools/libompd:
 set(LIBOMP_LIBRARY_DIR ${LIBOMP_LIBRARY_DIR} PARENT_SCOPE)
 set(LIBOMP_INCLUDE_DIR ${LIBOMP_INCLUDE_DIR} PARENT_SCOPE)
+set(LIBOMP_SRC_DIR ${LIBOMP_SRC_DIR} PARENT_SCOPE)


### PR DESCRIPTION
Modifications to correct out of source build failure due to the inclusion of kmp.h in omp-icv.cpp done as a part of PR#37. Patch provided by vigbalu.