### PR TITLE
OMPD unavailability error message for windows

### DIFF
--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -317,6 +317,10 @@ endif()
 set(LIBOMP_OMPD_SUPPORT FALSE CACHE BOOL
   "OMPD-support?")
 
+if(LIBOMP_OMPD_SUPPORT AND ((NOT LIBOMP_OMPT_SUPPORT) OR WIN32))
+  libomp_error_say("OpenMP Debug Interface(OMPD) requested but not available in this implementation")
+endif()
+
 # Error check hwloc support after config-ix has run
 if(LIBOMP_USE_HWLOC AND (NOT LIBOMP_HAVE_HWLOC))
   libomp_error_say("Hwloc requested but not available")


### PR DESCRIPTION
Error is thrown for OMPT on windows during configuration because certain APIs like LIBOMP_HAVE___BUILTIN_FRAME_ADDRESS are not supported. 
Enabling similar error message for OMPD 